### PR TITLE
added output variable "diags_sa_blob" which gives primary_blob_endpoint of storage account

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -9,6 +9,7 @@ output "diagnostics_map" {
     value = "${
         map(
             "diags_sa", azurerm_storage_account.log.id,
+            "diags_sa_blob", azurerm_storage_account.log.primary_blob_endpoint,
             "eh_name",  var.enable_event_hub == true ? azurerm_eventhub_namespace.log[0].name : null,
             "eh_id", var.enable_event_hub == true ? azurerm_eventhub_namespace.log[0].id : null,
         )

--- a/output.tf
+++ b/output.tf
@@ -10,6 +10,7 @@ output "diagnostics_map" {
         map(
             "diags_sa", azurerm_storage_account.log.id,
             "diags_sa_blob", azurerm_storage_account.log.primary_blob_endpoint,
+            "diags_sa_primary_access_key", azurerm_storage_account.log.primary_access_key,
             "eh_name",  var.enable_event_hub == true ? azurerm_eventhub_namespace.log[0].name : null,
             "eh_id", var.enable_event_hub == true ? azurerm_eventhub_namespace.log[0].id : null,
         )


### PR DESCRIPTION
added an output variable (diags_sa_blob) which gives primary_blob_endpoint of storage account. 
This output variable can be used for storage_uri value of boot_diagnostics block when creating VM. 