### PR TITLE
Fix for #8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.0.1 (March 2020)
+
+BUGS: 
+* **bug fix:**  error removing a the caf diagnostics logging module 2.0.0 ([#8](https://github.com/aztfmod/terraform-azurerm-caf-diagnostics-logging/issues/8))
+
+
 ## v2.0 (March 2020)
 
 FEATURES: 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
-provider "azurecaf" {
+# provider "azurecaf" {
   
-}
+# }
 
 locals {
   module_tag          = {


### PR DESCRIPTION
## v2.0.1 (March 2020)

BUGS: 
* **bug fix:**  error removing a the caf diagnostics logging module 2.0.0 ([#8](https://github.com/aztfmod/terraform-azurerm-caf-diagnostics-logging/issues/8))
